### PR TITLE
Fixes for MacOS path

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ kubectl get s3buckets.bucket.my.domain
 1. Run the controllers
 
 ```sh
+make setup
 make run
 ```
 

--- a/scripts/macos/setup_kind_env.sh
+++ b/scripts/macos/setup_kind_env.sh
@@ -26,9 +26,9 @@ cat << EOF > kind-config.yaml
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
-role: control-plane
-role: worker
-role: worker
+- role: control-plane
+- role: worker
+- role: worker
 EOF
 
 # Create the Kind cluster


### PR DESCRIPTION
Fixed required for MacOS walkthrogh. Modification to `setup_kind.sh` file was due to syntax issue and modification to `README` was to explicitly call make setup first to create the S3 bucket group before running make run.